### PR TITLE
Add depth prop to section

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,10 @@ function transform (tree) {
 
 function sectionize (node, ancestors) {
   const start = node
+  const depth = start.depth
   const parent = ancestors[ancestors.length - 1]
 
-  const isEnd = node => node.type === 'heading' && node.depth <= start.depth
+  const isEnd = node => node.type === 'heading' && node.depth <= depth
   const end = findAfter(parent, start, isEnd)
 
   const startIndex = parent.children.indexOf(start)
@@ -36,6 +37,7 @@ function sectionize (node, ancestors) {
 
   const section = {
     type: 'section',
+    depth: depth,
     children: between,
     data: {
       hName: 'section'

--- a/test.js
+++ b/test.js
@@ -44,40 +44,40 @@ test('sectionize', function (t) {
   `
 
   const expected = u('root', {}, [
-    u('section', { data: { hName: 'section' } }, [
+    u('section', { depth: 1, data: { hName: 'section' } }, [
       u('heading', { depth: 1 }, [u('text', { value: 'Heading 1' })]),
       u('paragraph', {}, [u('text', { value: 'Some text under heading 1.' })]),
-      u('section', { data: { hName: 'section' } }, [
+      u('section', { depth: 2, data: { hName: 'section' } }, [
         u('heading', { depth: 2 }, [u('text', { value: 'Heading 1.1' })]),
         u('paragraph', {}, [u('text', { value: 'Additional text.' })])
       ]),
-      u('section', { data: { hName: 'section' } }, [
+      u('section', { depth: 2, data: { hName: 'section' } }, [
         u('heading', { depth: 2 }, [u('text', { value: 'Heading 1.2' })]),
         u('paragraph', {}, [
           u('emphasis', {}, [u('text', { value: 'More' })]),
           u('text', { value: ' additional text.' })
         ]),
-        u('section', { data: { hName: 'section' } }, [
+        u('section', { depth: 3, data: { hName: 'section' } }, [
           u('heading', { depth: 3 }, [u('text', { value: 'Heading 1.2.1' })]),
           u('blockquote', {}, [
             u('paragraph', {}, [u('text', { value: 'Blockquote' })])
           ]),
           u('paragraph', {}, [u('text', { value: 'Text.' })]),
-          u('section', { data: { hName: 'section' } }, [
+          u('section', { depth: 5, data: { hName: 'section' } }, [
             u('heading', { depth: 5 }, [u('text', { value: 'Bad heading' })]),
             u('paragraph', {}, [u('text', { value: 'Lorem ipsum.' })])
           ])
         ]),
-        u('section', { data: { hName: 'section' } }, [
+        u('section', { depth: 3, data: { hName: 'section' } }, [
           u('heading', { depth: 3 }, [u('text', { value: 'Heading 1.2.2' })]),
           u('paragraph', {}, [u('text', { value: 'Dolor sit amet.' })])
         ])
       ])
     ]),
-    u('section', { data: { hName: 'section' } }, [
+    u('section', { depth: 1, data: { hName: 'section' } }, [
       u('heading', { depth: 1 }, [u('text', { value: 'Heading 2' })]),
       u('paragraph', {}, [u('text', { value: 'Another top level heading.' })]),
-      u('section', { data: { hName: 'section' } }, [
+      u('section', { depth: 6, data: { hName: 'section' } }, [
         u('heading', { depth: 6 }, [
           u('text', { value: 'Another bad heading' })
         ]),
@@ -90,7 +90,7 @@ test('sectionize', function (t) {
 
   sectionize()(tree)
   removePosition(tree, true)
-  t.deepEqual(expected, tree)
+  t.deepEqual(tree, expected)
 
   t.end()
 })


### PR DESCRIPTION
Adding depth prop to section (from child heading depth).

## Motivation
There can be a section depth of 6, directly under depth 1 (like in test.js#80).
Besides, I like to write selector more straightforwardly.

Here is my example in React app: 
[component](https://github.com/shogotsuneto/simple-md-shell/blob/sectionize-with-depth/src/components/contents/Section.js#L4)

```js
export default ({depth, children}) => <section className={styles[`section${depth}`]}>{children}</section>
```

[CSS is like this](https://github.com/shogotsuneto/simple-md-shell/blob/sectionize-with-depth/src/styles/Contents.module.css#L13).

I think accessing `children[0].depth` could spoil some flexibility.
See [caller](https://github.com/shogotsuneto/simple-md-shell/blob/sectionize-with-depth/src/components/contents/Tree.js#L7) of the above component.

I hope you consider merging this pull request.