### PR TITLE
Adding maxHeadingDepth and wrapOrphans options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.vscode

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ module.exports = {
 };
 ```
 
+## Options
+
+| Option | Type | Default | Description |
+| -------|------|---------|-------------|
+| `maxHeadingDepth` | `integer` | `6` | The maximum depth to look for headings to sectionize. For example, `2` means you would only create sections surrounding `h1` and `h2` tags. |
+| `wrapOrphans` | `boolean` | `false` | Whether you want to wrap orphaned content nodes. An orphaned content node would be a node under `root` without a `section` wrapper. This might happen if you start you document without a `heading`, like in cases where you have a page title defined in frontmatter.
+| `contentNodeTypes` | `string[]` | `['paragraph', 'code', blockquote']` | An array of node types to consider content for the purposes of finding orphans. Has no effect if `wrapOrphans` is `false`.
+
 ## License
 
 This repository is licensed under the MIT license; see the LICENSE file for details.

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 const findAfter = require('unist-util-find-after')
 const visit = require('unist-util-visit-parents')
 
-const MAX_HEADING_DEPTH = 6
-
 const defaults = {
-  maxHeadingDepth: MAX_HEADING_DEPTH,
+  maxHeadingDepth: 6,
   wrapIntro: false
 }
 

--- a/test.js
+++ b/test.js
@@ -6,8 +6,7 @@ const removePosition = require('unist-util-remove-position')
 
 const sectionize = require('.')
 
-test('sectionize', function (t) {
-  const document = dedent`
+const document = dedent`
     # Heading 1
 
     Some text under heading 1.
@@ -43,45 +42,73 @@ test('sectionize', function (t) {
     When will it end?
   `
 
+const documentSections = {
+  '1': [
+    u('heading', { depth: 1 }, [u('text', { value: 'Heading 1' })]),
+    u('paragraph', {}, [u('text', { value: 'Some text under heading 1.' })]),
+  ],
+  '1.1': [
+    u('heading', { depth: 2 }, [u('text', { value: 'Heading 1.1' })]),
+    u('paragraph', {}, [u('text', { value: 'Additional text.' })])  
+  ],
+  '1.2': [
+    u('heading', { depth: 2 }, [u('text', { value: 'Heading 1.2' })]),
+    u('paragraph', {}, [
+      u('emphasis', {}, [u('text', { value: 'More' })]),
+      u('text', { value: ' additional text.' })
+    ]),  
+  ],
+  '1.2.1': [
+    u('heading', { depth: 3 }, [u('text', { value: 'Heading 1.2.1' })]),
+    u('blockquote', {}, [
+      u('paragraph', {}, [u('text', { value: 'Blockquote' })])
+    ]),
+    u('paragraph', {}, [u('text', { value: 'Text.' })]),      
+  ],
+  '1.2.1-bad': [
+    u('heading', { depth: 5 }, [u('text', { value: 'Bad heading' })]),
+    u('paragraph', {}, [u('text', { value: 'Lorem ipsum.' })])      
+  ],
+  '1.2.2': [
+    u('heading', { depth: 3 }, [u('text', { value: 'Heading 1.2.2' })]),
+    u('paragraph', {}, [u('text', { value: 'Dolor sit amet.' })])      
+  ],
+  '2': [
+    u('heading', { depth: 1 }, [u('text', { value: 'Heading 2' })]),
+    u('paragraph', {}, [u('text', { value: 'Another top level heading.' })]),      
+  ],
+  '2-bad': [
+    u('heading', { depth: 6 }, [
+      u('text', { value: 'Another bad heading' })
+    ]),
+    u('paragraph', {}, [u('text', { value: 'When will it end?' })])      
+  ]
+}
+
+test('sectionize', function (t) {
   const expected = u('root', {}, [
     u('section', { depth: 1, data: { hName: 'section' } }, [
-      u('heading', { depth: 1 }, [u('text', { value: 'Heading 1' })]),
-      u('paragraph', {}, [u('text', { value: 'Some text under heading 1.' })]),
+      ...documentSections['1'],
       u('section', { depth: 2, data: { hName: 'section' } }, [
-        u('heading', { depth: 2 }, [u('text', { value: 'Heading 1.1' })]),
-        u('paragraph', {}, [u('text', { value: 'Additional text.' })])
+        ...documentSections['1.1']
       ]),
       u('section', { depth: 2, data: { hName: 'section' } }, [
-        u('heading', { depth: 2 }, [u('text', { value: 'Heading 1.2' })]),
-        u('paragraph', {}, [
-          u('emphasis', {}, [u('text', { value: 'More' })]),
-          u('text', { value: ' additional text.' })
-        ]),
+        ...documentSections['1.2'],
         u('section', { depth: 3, data: { hName: 'section' } }, [
-          u('heading', { depth: 3 }, [u('text', { value: 'Heading 1.2.1' })]),
-          u('blockquote', {}, [
-            u('paragraph', {}, [u('text', { value: 'Blockquote' })])
-          ]),
-          u('paragraph', {}, [u('text', { value: 'Text.' })]),
+          ...documentSections['1.2.1'],
           u('section', { depth: 5, data: { hName: 'section' } }, [
-            u('heading', { depth: 5 }, [u('text', { value: 'Bad heading' })]),
-            u('paragraph', {}, [u('text', { value: 'Lorem ipsum.' })])
+            ...documentSections['1.2.1-bad']
           ])
         ]),
         u('section', { depth: 3, data: { hName: 'section' } }, [
-          u('heading', { depth: 3 }, [u('text', { value: 'Heading 1.2.2' })]),
-          u('paragraph', {}, [u('text', { value: 'Dolor sit amet.' })])
+          ...documentSections['1.2.2']
         ])
       ])
     ]),
     u('section', { depth: 1, data: { hName: 'section' } }, [
-      u('heading', { depth: 1 }, [u('text', { value: 'Heading 2' })]),
-      u('paragraph', {}, [u('text', { value: 'Another top level heading.' })]),
+      ...documentSections['2'],
       u('section', { depth: 6, data: { hName: 'section' } }, [
-        u('heading', { depth: 6 }, [
-          u('text', { value: 'Another bad heading' })
-        ]),
-        u('paragraph', {}, [u('text', { value: 'When will it end?' })])
+        ...documentSections['2-bad']
       ])
     ])
   ])
@@ -89,6 +116,269 @@ test('sectionize', function (t) {
   const tree = remark().parse(document)
 
   sectionize()(tree)
+  removePosition(tree, true)
+  t.deepEqual(tree, expected)
+
+  t.end()
+})
+
+test('wrapIntro = true', function (t) {
+  const expected = u('root', {}, [
+    u('section', { depth: 1, data: { hName: 'section' } }, [
+      u('heading', { depth: 1 }, [u('text', { value: 'Heading 1' })]),
+      u('section', { depth: 2, data: { hName: 'section' } }, [
+        u("paragraph", { depth: 2 }, [u("text", { value: "Some text under heading 1." })]),
+      ]), 
+      u('section', { depth: 2, data: { hName: 'section' } }, [
+        ...documentSections['1.1']
+      ]),
+      u('section', { depth: 2, data: { hName: 'section' } }, [
+        ...documentSections['1.2'],
+        u('section', { depth: 3, data: { hName: 'section' } }, [
+          ...documentSections['1.2.1'],
+          u('section', { depth: 5, data: { hName: 'section' } }, [
+            ...documentSections['1.2.1-bad']
+          ])
+        ]),
+        u('section', { depth: 3, data: { hName: 'section' } }, [
+          ...documentSections['1.2.2']
+        ])
+      ])
+    ]),
+    u('section', { depth: 1, data: { hName: 'section' } }, [
+      ...documentSections['2'],
+      u('section', { depth: 6, data: { hName: 'section' } }, [
+        ...documentSections['2-bad']
+      ])
+    ])
+  ])
+
+
+  const tree = remark().parse(document)
+
+  sectionize({ wrapIntro: true })(tree)
+  removePosition(tree, true)
+  t.deepEqual(tree, expected)
+
+  t.end()
+})
+
+test('option maxHeadingDepth = 2', function (t) {
+  const expected = u('root', {}, [
+    u('section', { depth: 1, data: { hName: 'section' } }, [
+      ...documentSections['1'],
+      u('section', { depth: 2, data: { hName: 'section' } }, [
+        ...documentSections['1.1'],
+      ]),
+      u('section', { depth: 2, data: { hName: 'section' } }, [
+        ...documentSections['1.2'],
+        ...documentSections['1.2.1'],
+        ...documentSections['1.2.1-bad'],
+        ...documentSections['1.2.2']
+      ])
+    ]),
+    u('section', { depth: 1, data: { hName: 'section' } }, [
+      ...documentSections['2'],
+      ...documentSections['2-bad']
+    ])
+  ])
+
+  const tree = remark().parse(document)
+
+  sectionize({ maxHeadingDepth: 2 })(tree)
+  removePosition(tree, true)
+  t.deepEqual(tree, expected)
+
+  t.end()
+})
+
+test('maxHeadingDepth = 2, wrapIntro = true', function (t) {
+  const expected = u('root', {}, [
+    u('section', { depth: 1, data: { hName: 'section' } }, [
+      u('heading', { depth: 1 }, [u('text', { value: 'Heading 1' })]),
+      u('section', { depth: 2, data: { hName: 'section' } }, [
+        u("paragraph", { depth: 2 }, [u("text", { value: "Some text under heading 1." })]),
+      ]), 
+      u('section', { depth: 2, data: { hName: 'section' } }, [
+        ...documentSections['1.1'],
+      ]),
+      u('section', { depth: 2, data: { hName: 'section' } }, [
+        ...documentSections['1.2'],
+        ...documentSections['1.2.1'],
+        ...documentSections['1.2.1-bad'],
+        ...documentSections['1.2.2']
+      ])
+    ]),
+    u('section', { depth: 1, data: { hName: 'section' } }, [
+      ...documentSections['2'],
+      ...documentSections['2-bad']
+    ])
+  ])
+
+  const tree = remark().parse(document)
+
+  sectionize({ maxHeadingDepth: 2, wrapIntro: true })(tree)
+  removePosition(tree, true)
+  t.deepEqual(tree, expected)
+
+  t.end()
+})
+
+/**
+ * Markdown document without an h1 tag
+ */
+const documentNoH1 = dedent`
+    Some text under heading 1.
+
+    ## Heading 1.1
+
+    Additional text.
+
+    ## Heading 1.2
+
+    _More_ additional text.
+
+    ### Heading 1.2.1
+
+    > Blockquote
+
+    Text.
+
+    ##### Bad heading
+
+    Lorem ipsum.
+
+    ### Heading 1.2.2
+
+    Dolor sit amet.
+
+    Another top level heading.
+
+    ###### Another bad heading
+
+    When will it end?
+  `
+
+const documentNoH1Sections = {
+  '1': [
+    u('paragraph', {}, [u('text', { value: 'Some text under heading 1.' })]),
+  ],
+  '1.1': [
+    u('heading', { depth: 2 }, [u('text', { value: 'Heading 1.1' })]),
+    u('paragraph', {}, [u('text', { value: 'Additional text.' })])  
+  ],
+  '1.2': [
+    u('heading', { depth: 2 }, [u('text', { value: 'Heading 1.2' })]),
+    u('paragraph', {}, [
+      u('emphasis', {}, [u('text', { value: 'More' })]),
+      u('text', { value: ' additional text.' })
+    ]),  
+  ],
+  '1.2.1': [
+    u('heading', { depth: 3 }, [u('text', { value: 'Heading 1.2.1' })]),
+    u('blockquote', {}, [
+      u('paragraph', {}, [u('text', { value: 'Blockquote' })])
+    ]),
+    u('paragraph', {}, [u('text', { value: 'Text.' })]),      
+  ],
+  '1.2.1-bad': [
+    u('heading', { depth: 5 }, [u('text', { value: 'Bad heading' })]),
+    u('paragraph', {}, [u('text', { value: 'Lorem ipsum.' })])      
+  ],
+  '1.2.2': [
+    u('heading', { depth: 3 }, [u('text', { value: 'Heading 1.2.2' })]),
+    u('paragraph', {}, [u('text', { value: 'Dolor sit amet.' })])      
+  ],
+  '2': [
+    u('paragraph', {}, [u('text', { value: 'Another top level heading.' })]),      
+  ],
+  '2-bad': [
+    u('heading', { depth: 6 }, [
+      u('text', { value: 'Another bad heading' })
+    ]),
+    u('paragraph', {}, [u('text', { value: 'When will it end?' })])      
+  ]
+}
+
+test('no h1, maxHeadingDepth = 2', function (t) {
+  const expected = u('root', {}, [
+    ...documentNoH1Sections['1'],
+    u('section', { depth: 2, data: { hName: 'section' } }, [
+      ...documentNoH1Sections['1.1']
+    ]),
+    u('section', { depth: 2, data: { hName: 'section' } }, [
+      ...documentNoH1Sections['1.2'],
+      ...documentNoH1Sections['1.2.1'],
+      ...documentNoH1Sections['1.2.1-bad'],
+      ...documentNoH1Sections['1.2.2'],
+      ...documentNoH1Sections['2'],
+      ...documentNoH1Sections['2-bad'] 
+    ])
+  ])
+
+  const tree = remark().parse(documentNoH1)
+
+  sectionize({ maxHeadingDepth: 2 })(tree)
+  removePosition(tree, true)
+  t.deepEqual(tree, expected)
+
+  t.end()
+})
+
+test('no h1, maxHeadingDepth = 3', function (t) {
+  const expected = u('root', {}, [
+    ...documentNoH1Sections['1'],
+    u('section', { depth: 2, data: { hName: 'section' } }, [
+      ...documentNoH1Sections['1.1']
+    ]),
+    u('section', { depth: 2, data: { hName: 'section' } }, [
+      ...documentNoH1Sections['1.2'],
+      u('section', { depth: 3, data: { hName: 'section' } }, [
+        ...documentNoH1Sections['1.2.1'],
+        ...documentNoH1Sections['1.2.1-bad']
+      ]),
+      u('section', { depth: 3, data: { hName: 'section' } }, [
+        ...documentNoH1Sections['1.2.2'],
+        ...documentNoH1Sections['2'],
+        ...documentNoH1Sections['2-bad']   
+      ]),
+    ])
+  ])
+
+  const tree = remark().parse(documentNoH1)
+
+  sectionize({ maxHeadingDepth: 3 })(tree)
+  removePosition(tree, true)
+  t.deepEqual(tree, expected)
+
+  t.end()
+})
+
+test('no h1, maxHeadingDepth = 3, wrapIntro = true', function (t) {
+  const expected = u('root', {}, [
+    u('section', { depth: 1, data: { hName: 'section' } }, [
+      u("paragraph", { depth: 1 }, [u("text", { value: "Some text under heading 1." })]),
+    ]),
+    u('section', { depth: 2, data: { hName: 'section' } }, [
+      ...documentNoH1Sections['1.1']
+    ]),
+    u('section', { depth: 2, data: { hName: 'section' } }, [
+      ...documentNoH1Sections['1.2'],
+      u('section', { depth: 3, data: { hName: 'section' } }, [
+        ...documentNoH1Sections['1.2.1'],
+        ...documentNoH1Sections['1.2.1-bad']
+      ]),
+      u('section', { depth: 3, data: { hName: 'section' } }, [
+        ...documentNoH1Sections['1.2.2'],
+        ...documentNoH1Sections['2'],
+        ...documentNoH1Sections['2-bad']   
+      ]),
+    ])
+  ])
+
+  const tree = remark().parse(documentNoH1)
+
+  sectionize({ maxHeadingDepth: 3, wrapIntro: true })(tree)
   removePosition(tree, true)
   t.deepEqual(tree, expected)
 

--- a/test.js
+++ b/test.js
@@ -122,7 +122,7 @@ test('sectionize', function (t) {
   t.end()
 })
 
-test('wrapOrphans = true', function (t) {
+test('wrap orphans when none exist should do nothing', function (t) {
   const expected = u('root', {}, [
     u('section', { depth: 1, data: { hName: 'section' } }, [
       ...documentSections['1'],
@@ -160,7 +160,7 @@ test('wrapOrphans = true', function (t) {
   t.end()
 })
 
-test('option maxHeadingDepth = 2', function (t) {
+test('limit heading depth to h2', function (t) {
   const expected = u('root', {}, [
     u('section', { depth: 1, data: { hName: 'section' } }, [
       ...documentSections['1'],
@@ -189,7 +189,7 @@ test('option maxHeadingDepth = 2', function (t) {
   t.end()
 })
 
-test('maxHeadingDepth = 2, wrapOrphans = true', function (t) {
+test('limit heading depth to h2, wrap orphans should have no effect', function (t) {
   const expected = u('root', {}, [
     u('section', { depth: 1, data: { hName: 'section' } }, [
       ...documentSections['1'],
@@ -219,10 +219,12 @@ test('maxHeadingDepth = 2, wrapOrphans = true', function (t) {
 })
 
 /**
- * Markdown document without an h1 tag
+ * Markdown document without an h1 tag, and some leading orphans
  */
-const documentNoH1 = dedent`
-    Some text under heading 1.
+const documentWithOrphans = dedent`
+    > An orphaned blockquote.
+
+    And an orphaned paragraph.
 
     ## Heading 1.1
 
@@ -253,9 +255,12 @@ const documentNoH1 = dedent`
     When will it end?
   `
 
-const documentNoH1Sections = {
+const documentWithOrphansSections = {
   '1': [
-    u('paragraph', {}, [u('text', { value: 'Some text under heading 1.' })]),
+    u('blockquote', {}, [
+      u('paragraph', {}, [u('text', { value: 'An orphaned blockquote.' })])
+    ]),
+    u("paragraph", { }, [u("text", { value: "And an orphaned paragraph." })]),
   ],
   '1.1': [
     u('heading', { depth: 2 }, [u('text', { value: 'Heading 1.1' })]),
@@ -294,23 +299,23 @@ const documentNoH1Sections = {
   ]
 }
 
-test('no h1, maxHeadingDepth = 2', function (t) {
+test('orphaned content, do not wrap it, maxHeadingDepth = 2', function (t) {
   const expected = u('root', {}, [
-    ...documentNoH1Sections['1'],
+    ...documentWithOrphansSections['1'],
     u('section', { depth: 2, data: { hName: 'section' } }, [
-      ...documentNoH1Sections['1.1']
+      ...documentWithOrphansSections['1.1']
     ]),
     u('section', { depth: 2, data: { hName: 'section' } }, [
-      ...documentNoH1Sections['1.2'],
-      ...documentNoH1Sections['1.2.1'],
-      ...documentNoH1Sections['1.2.1-bad'],
-      ...documentNoH1Sections['1.2.2'],
-      ...documentNoH1Sections['2'],
-      ...documentNoH1Sections['2-bad'] 
+      ...documentWithOrphansSections['1.2'],
+      ...documentWithOrphansSections['1.2.1'],
+      ...documentWithOrphansSections['1.2.1-bad'],
+      ...documentWithOrphansSections['1.2.2'],
+      ...documentWithOrphansSections['2'],
+      ...documentWithOrphansSections['2-bad'] 
     ])
   ])
 
-  const tree = remark().parse(documentNoH1)
+  const tree = remark().parse(documentWithOrphans)
 
   sectionize({ maxHeadingDepth: 2 })(tree)
   removePosition(tree, true)
@@ -319,27 +324,27 @@ test('no h1, maxHeadingDepth = 2', function (t) {
   t.end()
 })
 
-test('no h1, maxHeadingDepth = 3', function (t) {
+test('orphaned content, do not wrap it, maxHeadingDepth = 3', function (t) {
   const expected = u('root', {}, [
-    ...documentNoH1Sections['1'],
+    ...documentWithOrphansSections['1'],
     u('section', { depth: 2, data: { hName: 'section' } }, [
-      ...documentNoH1Sections['1.1']
+      ...documentWithOrphansSections['1.1']
     ]),
     u('section', { depth: 2, data: { hName: 'section' } }, [
-      ...documentNoH1Sections['1.2'],
+      ...documentWithOrphansSections['1.2'],
       u('section', { depth: 3, data: { hName: 'section' } }, [
-        ...documentNoH1Sections['1.2.1'],
-        ...documentNoH1Sections['1.2.1-bad']
+        ...documentWithOrphansSections['1.2.1'],
+        ...documentWithOrphansSections['1.2.1-bad']
       ]),
       u('section', { depth: 3, data: { hName: 'section' } }, [
-        ...documentNoH1Sections['1.2.2'],
-        ...documentNoH1Sections['2'],
-        ...documentNoH1Sections['2-bad']   
+        ...documentWithOrphansSections['1.2.2'],
+        ...documentWithOrphansSections['2'],
+        ...documentWithOrphansSections['2-bad']   
       ]),
     ])
   ])
 
-  const tree = remark().parse(documentNoH1)
+  const tree = remark().parse(documentWithOrphans)
 
   sectionize({ maxHeadingDepth: 3 })(tree)
   removePosition(tree, true)
@@ -348,31 +353,63 @@ test('no h1, maxHeadingDepth = 3', function (t) {
   t.end()
 })
 
-test('no h1, maxHeadingDepth = 3, wrapOrphans = true', function (t) {
+test('wrap orphaned content, maxHeadingDepth = 3', function (t) {
   const expected = u('root', {}, [
     u('section', { depth: 1, data: { hName: 'section' } }, [
-      u("paragraph", { }, [u("text", { value: "Some text under heading 1." })]),
+      ...documentWithOrphansSections['1'],
     ]),
     u('section', { depth: 2, data: { hName: 'section' } }, [
-      ...documentNoH1Sections['1.1']
+      ...documentWithOrphansSections['1.1']
     ]),
     u('section', { depth: 2, data: { hName: 'section' } }, [
-      ...documentNoH1Sections['1.2'],
+      ...documentWithOrphansSections['1.2'],
       u('section', { depth: 3, data: { hName: 'section' } }, [
-        ...documentNoH1Sections['1.2.1'],
-        ...documentNoH1Sections['1.2.1-bad']
+        ...documentWithOrphansSections['1.2.1'],
+        ...documentWithOrphansSections['1.2.1-bad']
       ]),
       u('section', { depth: 3, data: { hName: 'section' } }, [
-        ...documentNoH1Sections['1.2.2'],
-        ...documentNoH1Sections['2'],
-        ...documentNoH1Sections['2-bad']   
+        ...documentWithOrphansSections['1.2.2'],
+        ...documentWithOrphansSections['2'],
+        ...documentWithOrphansSections['2-bad']   
       ]),
     ])
   ])
 
-  const tree = remark().parse(documentNoH1)
+  const tree = remark().parse(documentWithOrphans)
 
   sectionize({ maxHeadingDepth: 3, wrapOrphans: true })(tree)
+  removePosition(tree, true)
+  t.deepEqual(tree, expected)
+
+  t.end()
+})
+
+test('wrap orphaned content, skip first nodes that are not allowed', function (t) {
+  const expected = u('root', {}, [
+    documentWithOrphansSections['1'][0],
+    u('section', { depth: 1, data: { hName: 'section' } }, [
+      documentWithOrphansSections['1'][1]
+    ]),
+    u('section', { depth: 2, data: { hName: 'section' } }, [
+      ...documentWithOrphansSections['1.1']
+    ]),
+    u('section', { depth: 2, data: { hName: 'section' } }, [
+      ...documentWithOrphansSections['1.2'],
+      u('section', { depth: 3, data: { hName: 'section' } }, [
+        ...documentWithOrphansSections['1.2.1'],
+        ...documentWithOrphansSections['1.2.1-bad']
+      ]),
+      u('section', { depth: 3, data: { hName: 'section' } }, [
+        ...documentWithOrphansSections['1.2.2'],
+        ...documentWithOrphansSections['2'],
+        ...documentWithOrphansSections['2-bad']   
+      ]),
+    ])
+  ])
+
+  const tree = remark().parse(documentWithOrphans)
+
+  sectionize({ maxHeadingDepth: 3, wrapOrphans: true, contentNodeTypes: ['paragraph'] })(tree)
   removePosition(tree, true)
   t.deepEqual(tree, expected)
 

--- a/test.js
+++ b/test.js
@@ -122,13 +122,10 @@ test('sectionize', function (t) {
   t.end()
 })
 
-test('wrapIntro = true', function (t) {
+test('wrapOrphans = true', function (t) {
   const expected = u('root', {}, [
     u('section', { depth: 1, data: { hName: 'section' } }, [
-      u('heading', { depth: 1 }, [u('text', { value: 'Heading 1' })]),
-      u('section', { depth: 2, data: { hName: 'section' } }, [
-        u("paragraph", { depth: 2 }, [u("text", { value: "Some text under heading 1." })]),
-      ]), 
+      ...documentSections['1'],
       u('section', { depth: 2, data: { hName: 'section' } }, [
         ...documentSections['1.1']
       ]),
@@ -156,7 +153,7 @@ test('wrapIntro = true', function (t) {
 
   const tree = remark().parse(document)
 
-  sectionize({ wrapIntro: true })(tree)
+  sectionize({ wrapOrphans: true })(tree)
   removePosition(tree, true)
   t.deepEqual(tree, expected)
 
@@ -192,13 +189,10 @@ test('option maxHeadingDepth = 2', function (t) {
   t.end()
 })
 
-test('maxHeadingDepth = 2, wrapIntro = true', function (t) {
+test('maxHeadingDepth = 2, wrapOrphans = true', function (t) {
   const expected = u('root', {}, [
     u('section', { depth: 1, data: { hName: 'section' } }, [
-      u('heading', { depth: 1 }, [u('text', { value: 'Heading 1' })]),
-      u('section', { depth: 2, data: { hName: 'section' } }, [
-        u("paragraph", { depth: 2 }, [u("text", { value: "Some text under heading 1." })]),
-      ]), 
+      ...documentSections['1'],
       u('section', { depth: 2, data: { hName: 'section' } }, [
         ...documentSections['1.1'],
       ]),
@@ -217,7 +211,7 @@ test('maxHeadingDepth = 2, wrapIntro = true', function (t) {
 
   const tree = remark().parse(document)
 
-  sectionize({ maxHeadingDepth: 2, wrapIntro: true })(tree)
+  sectionize({ maxHeadingDepth: 2, wrapOrphans: true })(tree)
   removePosition(tree, true)
   t.deepEqual(tree, expected)
 
@@ -354,10 +348,10 @@ test('no h1, maxHeadingDepth = 3', function (t) {
   t.end()
 })
 
-test('no h1, maxHeadingDepth = 3, wrapIntro = true', function (t) {
+test('no h1, maxHeadingDepth = 3, wrapOrphans = true', function (t) {
   const expected = u('root', {}, [
     u('section', { depth: 1, data: { hName: 'section' } }, [
-      u("paragraph", { depth: 1 }, [u("text", { value: "Some text under heading 1." })]),
+      u("paragraph", { }, [u("text", { value: "Some text under heading 1." })]),
     ]),
     u('section', { depth: 2, data: { hName: 'section' } }, [
       ...documentNoH1Sections['1.1']
@@ -378,7 +372,7 @@ test('no h1, maxHeadingDepth = 3, wrapIntro = true', function (t) {
 
   const tree = remark().parse(documentNoH1)
 
-  sectionize({ maxHeadingDepth: 3, wrapIntro: true })(tree)
+  sectionize({ maxHeadingDepth: 3, wrapOrphans: true })(tree)
   removePosition(tree, true)
   t.deepEqual(tree, expected)
 


### PR DESCRIPTION
Hoping to add some functionality here which I needed while trying to accomplish a layout inspired by [tufte-css](https://edwardtufte.github.io/tufte-css/). 

In my case, I'd expect the h1 to be provided outside the main flow of the markdown document as the page title, and I would like to start with an introductory section without including a redundant `## Introduction` header. Thus the `wrapIntro` option I've added.

Further, I'd like to flatten the overall page structure and limit `<section>` tag creation to `h2`s.

Included are numerous tests, and the original test is passing. I've made the new features entirely optional, so as to no disrupt anybody already using this plugin.

I'm happy to explain any of the changes in this PR in more detail.

Thanks!